### PR TITLE
Chore final_fee calculation by removing unnecessary closure

### DIFF
--- a/core/src/from_substrate.rs
+++ b/core/src/from_substrate.rs
@@ -57,7 +57,7 @@ impl FeeDetails {
 		self.inclusion_fee
 			.as_ref()
 			.map(|i| i.inclusion_fee())
-			.unwrap_or_else(|| 0u128)
+			.unwrap_or(0)
 			.saturating_add(self.tip)
 	}
 }

--- a/core/src/rpc/author.rs
+++ b/core/src/rpc/author.rs
@@ -16,7 +16,7 @@ impl TryFrom<&[u8]> for SessionKeys {
 
 	fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
 		if value.len() != 128 {
-			return Err(String::from("Session keys len cannot have length be more or less than 128"));
+			return Err(format!("Session keys length must be exactly 128 bytes, got {}", value.len()));
 		}
 
 		let err = |e: TryFromSliceError| e.to_string();


### PR DESCRIPTION
- Chore final_fee calculation by removing unnecessary closure
- Fix misleading error message in SessionKeys validation