### PR TITLE
Remove unnecessary vector allocations in RPC

### DIFF
--- a/client/src/transaction.rs
+++ b/client/src/transaction.rs
@@ -49,7 +49,7 @@ impl SubmittableTransaction {
 		&self,
 		signer: &Keypair,
 		options: Options,
-	) -> Result<avail_rust_core::Transaction, avail_rust_core::Error> {
+	) -> Result<avail_rust_core::Transaction<'_>, avail_rust_core::Error> {
 		self.client.sign_call(signer, &self.call, options).await
 	}
 

--- a/core/src/rpc/kate.rs
+++ b/core/src/rpc/kate.rs
@@ -34,7 +34,7 @@ pub struct GProof(pub [u8; 48]);
 
 impl From<GProof> for Vec<u8> {
 	fn from(proof: GProof) -> Self {
-		proof.0.to_vec()
+		proof.0.into()
 	}
 }
 
@@ -152,7 +152,7 @@ pub async fn query_multi_proof(
 	at: Option<H256>,
 	cells: Vec<Cell>,
 ) -> Result<Vec<(GMultiProof, GCellBlock)>, subxt_rpcs::Error> {
-	let params = rpc_params![cells.to_vec(), at];
+	let params = rpc_params![cells, at];
 	let proofs: Vec<(GMultiProof, GCellBlock)> = client.request("kate_queryMultiProof", params).await?;
 
 	Ok(proofs)


### PR DESCRIPTION
1. query_multi_proof(): Removed redundant cells.to_vec() since cells is already Vec<Cell>
2. GProof From implementation: Replaced proof.0.to_vec() with proof.0.into()